### PR TITLE
:pencil2: Split for X and y

### DIFF
--- a/Basic_Machine_Learning_Predicts.ipynb
+++ b/Basic_Machine_Learning_Predicts.ipynb
@@ -319,7 +319,7 @@
         "from sklearn.model_selection import train_test_split\n",
         "\n",
         "# Split X and y into X_\n",
-        "X_train, X_test, y_train, y_test = train_test_split(df, y, test_size=0.25,  random_state=0)"
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25,  random_state=0)"
       ],
       "outputs": [],
       "execution_count": 6,


### PR DESCRIPTION
Found that it was splitting `df` and `y` instead of `X`. Otherwise, `X` isn't used and the resulting variables wouldn't make sense. Unless its supposed to be `df_train` and `df_test`.